### PR TITLE
Refine error handling

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,4 +10,4 @@ jobs:
       - name: docker build
         run: make build
       - name: docker compose up
-        run: timeout --preserve-status 15 docker-compose up --exit-code-from slot_checker
+        run: timeout --preserve-status 15 docker-compose up --exit-code-from slot_checker || if [ $? -eq 42 ]; then exit 0; else exit 1; fi

--- a/src/exceptions.py
+++ b/src/exceptions.py
@@ -1,0 +1,40 @@
+"""Slot checker exceptions"""
+
+import logging as log
+import traceback
+
+
+def slot_checker_exception(exception, msg=None):
+    """Exception handler
+
+    All caught exceptions should call this function.
+    Captures traceback unless debug logs are activated.
+    Raises generic SlotCheckerException before program terminates.
+
+    Args:
+        - exception: exception initially caught
+        - msg: optional custom error log
+    """
+
+    if msg is not None:
+        exc = exception.__name__ if hasattr(exception, __name__) else exception
+        log.error(msg)
+        log.error("Error originating from %s", exc)
+    debug = log.getLogger().getEffectiveLevel() == log.DEBUG
+    if not debug:
+        log.warning("Traceback may be suppressed. Activate debug logs to see.")
+    else:
+        traceback.print_exc()
+    raise SlotCheckerException()
+
+
+class SlotCheckerException(Exception):
+    """Generic Slot Checker exception"""
+
+
+class IntraFailedSignin(ConnectionRefusedError):
+    """Exception raised upon failed login attempt"""
+
+
+class SlotCheckError(Exception):
+    """Exception raised when slots retrieval fails"""

--- a/src/exceptions.py
+++ b/src/exceptions.py
@@ -25,11 +25,15 @@ def slot_checker_exception(exception, msg=None):
         log.warning("Traceback may be suppressed. Activate debug logs to see.")
     else:
         traceback.print_exc()
-    raise SlotCheckerException()
+    raise SlotCheckerException(exception)
 
 
 class SlotCheckerException(Exception):
     """Generic Slot Checker exception"""
+
+    def __init__(self, origin):
+        super().__init__()
+        self.error_code = 42 if origin == IntraFailedSignin else 1
 
 
 class IntraFailedSignin(ConnectionRefusedError):

--- a/src/slot_checker.py
+++ b/src/slot_checker.py
@@ -267,4 +267,4 @@ if __name__ == "__main__":
 
     except SlotCheckerException as e:
         log.error("Aborting following an error while running the Slot Checker")
-        sys.exit(1)
+        sys.exit(e.error_code)


### PR DESCRIPTION
Refactor error handling to:
- remove sys.exit and os._exit peppered around the program
- unify error handling and logs by bubbling them up towards the main
- fine-tune logs -> traceback will be suppressed unless verbose mode is on
- prevent CI from failing upon (logical) failed login attempt by intercepting failed login with error code 42 via bash and replacing with 0

Regarding the CI, be aware that the program never runs beyond the failed login attempt, so CI will only catch broad and early-on problems and will not be able to tell if anything goes wrong after that.