### PR TITLE
Fix crash due to uncaught httpx errors when getting slots

### DIFF
--- a/src/slot_checker.py
+++ b/src/slot_checker.py
@@ -79,7 +79,7 @@ class Intra(object):
                 f"{get_slot_url(project)}/slots.json?start={start}&end={end}", timeout=3.05
             )
             slots = r.json()
-        except httpx.RequestError as err:
+        except (httpx.RequestError, httpx.ReadTimeout, httpx.ConnectError) as err:
             if retries < max_retries:
                 log.debug("Failed attempt #%d to get projects slots (max %d)", retries, max_retries)
                 self.get_project_slots(project, start, end, retries + 1)


### PR DESCRIPTION
This fix attempts to catch additional identified httpx timeout and
connection errors.
If errors continue, we should try catch a generic Exception.